### PR TITLE
Add ends_in data to sensor even if loadshedding hasn't started yet

### DIFF
--- a/custom_components/load_shedding/sensor.py
+++ b/custom_components/load_shedding/sensor.py
@@ -416,6 +416,11 @@ def get_sensor_attrs(forecast: list, stage: Stage = Stage.NO_LOAD_SHEDDING) -> d
         data[ATTR_NEXT_START_TIME] = nxt.get(ATTR_START_TIME).isoformat()
         if ATTR_END_TIME in nxt:
             data[ATTR_NEXT_END_TIME] = nxt.get(ATTR_END_TIME).isoformat()
+            end_time = nxt.get(ATTR_END_TIME)
+            ends_in = end_time - now
+            ends_in = ends_in - timedelta(microseconds=ends_in.microseconds)
+            ends_in = int(ends_in.total_seconds() / 60)  # minutes
+            data[ATTR_END_IN] = ends_in
 
         start_time = nxt.get(ATTR_START_TIME)
         starts_in = start_time - now


### PR DESCRIPTION
This is useful if you have an automation or similar that needs to see how long loadshedding will last