### PR TITLE
Correct automation example link for the 2 hour warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Replace `sensor.load_shedding_south_africa_stage`, `sensor.load_shedding_milnert
 - [Load Shedding (Warning)](examples/automation2.yaml)
 
 ### 2 hour warning on speaker
-- [Load Shedding (Warning) (2hr)](examples/automation3.yaml)
+- [Load Shedding (Warning) (2hr)](examples/automation5.yaml)
 
 ### Update your Slack status
 


### PR DESCRIPTION
In the automation examples section of the README, the configuration that is linked to is automation3.yaml, which is the same as the automation to update a Slack status. The correct configuration for this example is automation5.yaml. This pull request updates the link to point to the correct configuration example file.