### PR TITLE
feat: persist coordinator cache to survive HA restarts (#116)

### DIFF
--- a/custom_components/load_shedding/__init__.py
+++ b/custom_components/load_shedding/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from datetime import UTC, datetime, timedelta, timezone
 import logging
 from typing import Any
@@ -26,6 +27,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -58,6 +60,104 @@ _LOGGER = logging.getLogger(__name__)
 DIAG_CONTEXT = f"[load_shedding {VERSION}, Home Assistant {HA_VERSION}]"
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
+
+_STORE_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Coordinator cache serialisation helpers
+# ---------------------------------------------------------------------------
+# Stage and area coordinator data contains Stage enums and datetime objects
+# that must be flattened to JSON-safe primitives before writing to Store and
+# re-inflated after loading.  Deserialization failures are suppressed in the
+# callers so a corrupt/incompatible cache silently falls back to a live poll.
+
+
+def _serialize_stage_data(data: dict) -> dict:
+    result: dict = {}
+    for zone_id, zone_data in data.items():
+        planned = [
+            {
+                ATTR_STAGE: slot[ATTR_STAGE].value,
+                ATTR_START_TIME: slot[ATTR_START_TIME].isoformat(),
+                ATTR_END_TIME: slot[ATTR_END_TIME].isoformat(),
+            }
+            for slot in zone_data.get(ATTR_PLANNED, [])
+        ]
+        result[zone_id] = {ATTR_NAME: zone_data.get(ATTR_NAME, ""), ATTR_PLANNED: planned}
+    return result
+
+
+def _deserialize_stage_data(stored: dict) -> dict:
+    result: dict = {}
+    for zone_id, zone_data in stored.items():
+        planned = [
+            {
+                ATTR_STAGE: Stage(int(slot[ATTR_STAGE])),
+                ATTR_START_TIME: datetime.fromisoformat(slot[ATTR_START_TIME]),
+                ATTR_END_TIME: datetime.fromisoformat(slot[ATTR_END_TIME]),
+            }
+            for slot in zone_data.get(ATTR_PLANNED, [])
+        ]
+        result[zone_id] = {ATTR_NAME: zone_data.get(ATTR_NAME, ""), ATTR_PLANNED: planned}
+    return result
+
+
+def _serialize_area_data(data: dict) -> dict:
+    # Only events + schedule are persisted; forecast is derived and recomputed.
+    result: dict = {}
+    for area_id, area_data in data.items():
+        events = [
+            {
+                ATTR_STAGE: s[ATTR_STAGE].value,
+                ATTR_START_TIME: s[ATTR_START_TIME].isoformat(),
+                ATTR_END_TIME: s[ATTR_END_TIME].isoformat(),
+            }
+            for s in area_data.get(ATTR_EVENTS, [])
+        ]
+        schedule: dict[str, list] = {}
+        for stage, slots in area_data.get(ATTR_SCHEDULE, {}).items():
+            schedule[str(stage.value)] = [
+                {
+                    ATTR_STAGE: s[ATTR_STAGE].value,
+                    ATTR_START_TIME: s[ATTR_START_TIME].isoformat(),
+                    ATTR_END_TIME: s[ATTR_END_TIME].isoformat(),
+                }
+                for s in slots
+            ]
+        result[area_id] = {ATTR_EVENTS: events, ATTR_SCHEDULE: schedule}
+    return result
+
+
+def _deserialize_area_data(stored: dict) -> dict:
+    result: dict = {}
+    for area_id, area_data in stored.items():
+        events = [
+            {
+                ATTR_STAGE: Stage(int(s[ATTR_STAGE])),
+                ATTR_START_TIME: datetime.fromisoformat(s[ATTR_START_TIME]),
+                ATTR_END_TIME: datetime.fromisoformat(s[ATTR_END_TIME]),
+            }
+            for s in area_data.get(ATTR_EVENTS, [])
+        ]
+        schedule: dict[Stage, list] = {}
+        for stage_val, slots in area_data.get(ATTR_SCHEDULE, {}).items():
+            stage = Stage(int(stage_val))
+            schedule[stage] = [
+                {
+                    ATTR_STAGE: Stage(int(s[ATTR_STAGE])),
+                    ATTR_START_TIME: datetime.fromisoformat(s[ATTR_START_TIME]),
+                    ATTR_END_TIME: datetime.fromisoformat(s[ATTR_END_TIME]),
+                }
+                for s in slots
+            ]
+        result[area_id] = {ATTR_EVENTS: events, ATTR_SCHEDULE: schedule}
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Integration setup / teardown
+# ---------------------------------------------------------------------------
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -129,6 +229,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     config_entry.async_on_unload(config_entry.add_update_listener(update_listener))
 
+    # Restore persisted timestamps and data so the first refresh skips the
+    # SePush API when the cached values are still within the update interval.
+    # This prevents quota exhaustion on every HA restart (#116).
+    await stage_coordinator.async_load_cache()
+    await area_coordinator.async_load_cache()
+
     await stage_coordinator.async_config_entry_first_refresh()
     await area_coordinator.async_config_entry_first_refresh()
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
@@ -142,6 +248,14 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         config_entry, PLATFORMS
     )
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+    """Remove Load Shedding config entry and wipe persisted coordinator caches."""
+    for kind in ("stage", "area"):
+        await Store(
+            hass, version=_STORE_VERSION, key=f"{DOMAIN}.{kind}.{config_entry.entry_id}"
+        ).async_remove()
 
 
 async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
@@ -216,6 +330,11 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
+# ---------------------------------------------------------------------------
+# Coordinators
+# ---------------------------------------------------------------------------
+
+
 class LoadSheddingStageCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching LoadShedding Stage."""
 
@@ -228,6 +347,35 @@ class LoadSheddingStageCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.sepush = sepush
         self.last_update: datetime | None = None
         self._entry_id = entry_id
+        self._store: Store = Store(
+            hass, version=_STORE_VERSION, key=f"{DOMAIN}.stage.{entry_id}"
+        )
+
+    async def async_load_cache(self) -> None:
+        """Pre-seed last_update and data from persistent storage.
+
+        When the cache is fresh (within STAGE_UPDATE_INTERVAL), the first call
+        to _async_update_data will return the cached data without hitting the
+        SePush API, preventing quota exhaustion on every HA restart (#116).
+        """
+        stored = await self._store.async_load()
+        if not stored:
+            return
+        with contextlib.suppress(Exception):
+            self.last_update = datetime.fromisoformat(stored["last_update"])
+            self.data = _deserialize_stage_data(stored.get("data", {}))
+            _LOGGER.debug(
+                "Restored stage cache (last_update=%s) %s", self.last_update, DIAG_CONTEXT
+            )
+
+    async def _save_cache(self) -> None:
+        """Persist last_update and data after a successful API poll."""
+        await self._store.async_save(
+            {
+                "last_update": self.last_update.isoformat() if self.last_update else None,
+                "data": _serialize_stage_data(self.data),
+            }
+        )
 
     async def _async_update_data(self) -> dict:
         """Retrieve latest load shedding data."""
@@ -255,6 +403,7 @@ class LoadSheddingStageCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         else:
             self.data = stage
             self.last_update = now
+            await self._save_cache()
             ir.async_delete_issue(
                 self.hass, DOMAIN, f"sepush_api_failure_{self._entry_id}"
             )
@@ -373,10 +522,40 @@ class LoadSheddingAreaCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.stage_coordinator = stage_coordinator
         self._entry_id = entry_id
         self._invalid_area_ids: set[str] = set()
+        self._store: Store = Store(
+            hass, version=_STORE_VERSION, key=f"{DOMAIN}.area.{entry_id}"
+        )
 
     def add_area(self, area: Area = None) -> None:
         """Add a area to update."""
         self.areas.append(area)
+
+    async def async_load_cache(self) -> None:
+        """Pre-seed last_update and data from persistent storage.
+
+        When the cache is fresh (within AREA_UPDATE_INTERVAL), the first call
+        to _async_update_data will skip the SePush API and recompute the
+        forecast from the cached schedule, preventing quota exhaustion on every
+        HA restart (#116).
+        """
+        stored = await self._store.async_load()
+        if not stored:
+            return
+        with contextlib.suppress(Exception):
+            self.last_update = datetime.fromisoformat(stored["last_update"])
+            self.data = _deserialize_area_data(stored.get("data", {}))
+            _LOGGER.debug(
+                "Restored area cache (last_update=%s) %s", self.last_update, DIAG_CONTEXT
+            )
+
+    async def _save_cache(self) -> None:
+        """Persist last_update and data after a successful API poll."""
+        await self._store.async_save(
+            {
+                "last_update": self.last_update.isoformat() if self.last_update else None,
+                "data": _serialize_area_data(self.data),
+            }
+        )
 
     async def _async_update_data(self) -> dict:
         """Retrieve latest load shedding data."""
@@ -402,6 +581,7 @@ class LoadSheddingAreaCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # schedule instead of disappearing until the next update interval.
             self.data = {**self.data, **area}
             self.last_update = now
+            await self._save_cache()
 
         await self.async_area_forecast()
         return self.data

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 """Tests for the Load Shedding integration setup, unload and coordinators."""
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from load_shedding.libs.sepush import SePushError
@@ -12,15 +12,21 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_NAME, CONF_API_KEY, CONF_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.load_shedding import (
     LoadSheddingAreaCoordinator,
     LoadSheddingStageCoordinator,
+    _deserialize_area_data,
+    _deserialize_stage_data,
+    _serialize_area_data,
+    _serialize_stage_data,
     async_migrate_entry,
     utc_dt,
 )
 from custom_components.load_shedding.const import (
+    AREA_UPDATE_INTERVAL,
     ATTR_AREA,
     ATTR_EVENTS,
     ATTR_FORECAST,
@@ -445,6 +451,202 @@ def test_utc_dt() -> None:
     time = datetime(1900, 1, 1, 20, 0)
     result = utc_dt(date, time)
     assert result == datetime(2026, 6, 18, 18, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Cache serialisation round-trip tests (#116)
+# ---------------------------------------------------------------------------
+
+
+def test_stage_cache_round_trip() -> None:
+    """Stage coordinator data serialises to JSON and back without data loss."""
+    now = datetime(2026, 6, 18, 8, 0, tzinfo=UTC)
+    data = {
+        "eskom": {
+            "name": "National",
+            ATTR_PLANNED: [
+                {
+                    ATTR_STAGE: Stage.STAGE_2,
+                    ATTR_START_TIME: now,
+                    ATTR_END_TIME: now + timedelta(hours=2),
+                },
+            ],
+        },
+    }
+    assert _deserialize_stage_data(_serialize_stage_data(data)) == data
+
+
+def test_area_cache_round_trip() -> None:
+    """Area coordinator data serialises to JSON and back without data loss."""
+    now = datetime(2026, 6, 18, 8, 0, tzinfo=UTC)
+    data = {
+        "za_gt_tsh_garsfontein_gaev": {
+            ATTR_EVENTS: [
+                {
+                    ATTR_STAGE: Stage.STAGE_2,
+                    ATTR_START_TIME: now,
+                    ATTR_END_TIME: now + timedelta(hours=2),
+                },
+            ],
+            ATTR_SCHEDULE: {
+                Stage.STAGE_2: [
+                    {
+                        ATTR_STAGE: Stage.STAGE_2,
+                        ATTR_START_TIME: now,
+                        ATTR_END_TIME: now + timedelta(hours=2),
+                    },
+                ],
+            },
+        },
+    }
+    assert _deserialize_area_data(_serialize_area_data(data)) == data
+
+
+async def test_stage_coordinator_cache_skips_api_on_restart(
+    hass: HomeAssistant,
+    mock_sepush: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Stage coordinator does not call the API when a fresh cache is loaded on restart.
+
+    Simulates the scenario described in issue #116: the cache is pre-seeded with
+    a last_update that is still within STAGE_UPDATE_INTERVAL, so the first
+    refresh must return the cached data without hitting SePush.
+    """
+    freezer.move_to(FROZEN_TIME)
+    frozen_now = datetime.fromisoformat(FROZEN_TIME)
+
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+
+    # Pre-populate the coordinator's store so async_load_cache restores it.
+    store_data = {
+        "last_update": frozen_now.isoformat(),
+        "data": _serialize_stage_data(
+            {
+                "eskom": {
+                    "name": "National",
+                    ATTR_PLANNED: [
+                        {
+                            ATTR_STAGE: Stage.STAGE_2,
+                            ATTR_START_TIME: frozen_now - timedelta(hours=1),
+                            ATTR_END_TIME: frozen_now + timedelta(hours=1),
+                        }
+                    ],
+                }
+            }
+        ),
+    }
+
+    async def _fake_load():
+        return store_data
+
+    with patch.object(Store, "async_load", side_effect=_fake_load):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # The API should not have been called for stage — cache was fresh.
+    mock_sepush.status.assert_not_called()
+
+
+async def test_area_coordinator_cache_skips_api_on_restart(
+    hass: HomeAssistant,
+    mock_sepush: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Area coordinator does not call the API when a fresh cache is loaded on restart.
+
+    Simulates the scenario described in issue #116: the area schedule is valid
+    for 24 h so it must never be re-fetched on a restart that occurs within that
+    window.
+    """
+    freezer.move_to(FROZEN_TIME)
+    frozen_now = datetime.fromisoformat(FROZEN_TIME)
+
+    entry = build_config_entry()
+    entry.add_to_hass(hass)
+
+    area_store_data = {
+        "last_update": frozen_now.isoformat(),
+        "data": _serialize_area_data(
+            {
+                AREA_ID: {
+                    ATTR_EVENTS: [],
+                    ATTR_SCHEDULE: {
+                        Stage.STAGE_2: [
+                            {
+                                ATTR_STAGE: Stage.STAGE_2,
+                                ATTR_START_TIME: frozen_now + timedelta(hours=12),
+                                ATTR_END_TIME: frozen_now + timedelta(hours=14),
+                            }
+                        ]
+                    },
+                }
+            }
+        ),
+    }
+
+    async def _fake_load():
+        return area_store_data
+
+    with patch.object(Store, "async_load", side_effect=_fake_load):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    # Area API must not have been called — cache was fresh.
+    mock_sepush.area.assert_not_called()
+
+
+async def test_stage_coordinator_saves_cache_after_successful_poll(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Stage coordinator persists data after a successful API poll."""
+    entry = init_integration
+    coordinator: LoadSheddingStageCoordinator = hass.data[DOMAIN][entry.entry_id][
+        ATTR_STAGE
+    ]
+    saved: list[dict] = []
+
+    async def _capture(data):
+        saved.append(data)
+
+    coordinator._store.async_save = _capture  # type: ignore[method-assign]
+
+    coordinator.last_update = None  # Force a refresh on next call.
+    freezer.tick(timedelta(seconds=STAGE_UPDATE_INTERVAL + 1))
+    await coordinator._async_update_data()
+
+    assert saved, "Store.async_save was never called after a successful API poll"
+    assert "last_update" in saved[0]
+    assert "data" in saved[0]
+
+
+async def test_area_coordinator_saves_cache_after_successful_poll(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Area coordinator persists data after a successful API poll."""
+    entry = init_integration
+    coordinator: LoadSheddingAreaCoordinator = hass.data[DOMAIN][entry.entry_id][
+        ATTR_AREA
+    ]
+    saved: list[dict] = []
+
+    async def _capture(data):
+        saved.append(data)
+
+    coordinator._store.async_save = _capture  # type: ignore[method-assign]
+
+    coordinator.last_update = None  # Force a refresh on next call.
+    freezer.tick(timedelta(seconds=AREA_UPDATE_INTERVAL + 1))
+    await coordinator._async_update_data()
+
+    assert saved, "Store.async_save was never called after a successful API poll"
+    assert "last_update" in saved[0]
+    assert "data" in saved[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -515,13 +515,16 @@ async def test_stage_coordinator_cache_skips_api_on_restart(
     """
     freezer.move_to(FROZEN_TIME)
     frozen_now = datetime.fromisoformat(FROZEN_TIME)
+    # last_update must be strictly before now so diff > 0; when diff == 0
+    # should_refresh() returns True (see helpers.should_refresh docstring).
+    cache_time = frozen_now - timedelta(seconds=1)
 
     entry = build_config_entry()
     entry.add_to_hass(hass)
 
     # Pre-populate the coordinator's store so async_load_cache restores it.
     store_data = {
-        "last_update": frozen_now.isoformat(),
+        "last_update": cache_time.isoformat(),
         "data": _serialize_stage_data(
             {
                 "eskom": {
@@ -562,12 +565,15 @@ async def test_area_coordinator_cache_skips_api_on_restart(
     """
     freezer.move_to(FROZEN_TIME)
     frozen_now = datetime.fromisoformat(FROZEN_TIME)
+    # last_update must be strictly before now so diff > 0; when diff == 0
+    # should_refresh() returns True (see helpers.should_refresh docstring).
+    cache_time = frozen_now - timedelta(seconds=1)
 
     entry = build_config_entry()
     entry.add_to_hass(hass)
 
     area_store_data = {
-        "last_update": frozen_now.isoformat(),
+        "last_update": cache_time.isoformat(),
         "data": _serialize_area_data(
             {
                 AREA_ID: {


### PR DESCRIPTION
## Summary

Persist coordinator cache to HA storage so SePush API is not called on every HA restart.

### Root cause (#116)

`LoadSheddingStageCoordinator` and `LoadSheddingAreaCoordinator` initialise with `last_update = None`, so `should_refresh()` always returns `True` on the first tick — including immediately after a restart. This wastes one API call per coordinator per restart (stage + each area), burning through the daily SePush quota.

### Fix

- Added `async_load_cache()` to both coordinators, called from `async_setup_entry` before `async_config_entry_first_refresh`.  When stored data exists and `last_update` is still within the update interval, the first refresh returns cached data without hitting the API.
- Added `_save_cache()`, called at the end of every successful live poll to keep the persisted timestamp fresh.
- Cache is stored via `homeassistant.helpers.storage.Store` (keyed `load_shedding.{stage|area}.{entry_id}`).
- `async_remove_entry` wipes both stores when the integration is removed.
- Serialisation helpers (`_serialize_*` / `_deserialize_*`) flatten `Stage` enums and `datetime` objects to JSON-safe primitives and restore them on load.

### Tests added

- `test_stage_cache_round_trip` / `test_area_cache_round_trip` — pure serialisation round-trips, no HA fixture needed.
- `test_stage_coordinator_cache_skips_api_on_restart` — fresh cache pre-seeded; asserts `sepush.status` is never called.
- `test_area_coordinator_cache_skips_api_on_restart` — same for `sepush.area`.
- `test_stage_coordinator_saves_cache_after_successful_poll` / `test_area_coordinator_saves_cache_after_successful_poll` — asserts `Store.async_save` is called with `last_update` and `data` keys after a live poll.

Closes #116
