### PR TITLE
fix(sensor): restore quota sensor state on restart

### DIFF
--- a/custom_components/load_shedding/sensor.py
+++ b/custom_components/load_shedding/sensor.py
@@ -329,6 +329,12 @@ class LoadSheddingQuotaSensorEntity(
         self._attr_unique_id = f"{self.coordinator.config_entry.entry_id}_se_push_quota"
         self.entity_id = f"{SENSOR_DOMAIN}.{DOMAIN}_sepush_api_quota"
 
+    async def async_added_to_hass(self) -> None:
+        """Handle entity which will be added."""
+        if restored_data := await self.async_get_last_sensor_data():
+            self._attr_native_value = restored_data.native_value
+        await super().async_added_to_hass()
+
     @property
     def name(self) -> str | None:
         """Return the quota sensor name."""


### PR DESCRIPTION
## Problem

`LoadSheddingQuotaSensorEntity` inherits `RestoreSensor` but was missing `async_added_to_hass`, causing the sensor to show `Unknown` after every HA restart until the next coordinator poll.

## Fix

Added the same `async_added_to_hass` restore pattern already used by `LoadSheddingStageSensorEntity` and `LoadSheddingAreaSensorEntity`.

## Root cause

Regression — quota sensor was never given the restore hook that the other sensors have.